### PR TITLE
Was not displaying posters in alphabetical order, fixed with sort_by

### DIFF
--- a/app/models/poster.rb
+++ b/app/models/poster.rb
@@ -10,7 +10,8 @@ class Poster < ApplicationRecord
 
   def self.filter_by_name(name_param)
     posters = Poster.all
-    poster = posters.find_all { |poster| poster.name.include?(name_param.upcase) }
+    found_posters = posters.find_all { |poster| poster.name.include?(name_param.upcase) }
+    poster = found_posters.sort_by { |poster| poster.name }
   end
 
   def self.filter_by_max_price(price_param)


### PR DESCRIPTION
Found a bug while practice presenting, had to add another enumerable after filter_by_name posters were found. Made sure program could sort the found_posters by alphabetical order by name. 